### PR TITLE
Fix typo in testJsonInlineFail test

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -98,7 +98,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
      */
     public function testJsonInlineFail()
     {
-        $repository = $this->config->load('{ "var": "value"', Config::TYPE_TOML);
+        $repository = $this->config->load('{ "var": "value"', Config::TYPE_JSON);
     }
 
     /**


### PR DESCRIPTION
Hello,
seems there should be used TYPE_JSON instead of TYPE_TOML. 
This PR will fix it.