### PR TITLE
Don't check is_file when $resource is really long

### DIFF
--- a/src/Loaders/YamlLoader.php
+++ b/src/Loaders/YamlLoader.php
@@ -32,7 +32,7 @@ class YamlLoader extends ConfigFileLoader
             $resource = $this->getLocation($resource);
         }
 
-        if (is_file($resource)) {
+        if ((!is_string($resource) || strlen($resource)<4096) && is_file($resource)) {
             if (!is_readable($resource)) {
                 throw new \RuntimeException(sprintf('Unable to parse "%s" as the file is not readable.', $resource));
             }


### PR DESCRIPTION
I came across this while running Spress on a file with a really really long frontmatter.
`is_file` gives a warning message if you pass in a string of 4096 characters or more. I'm not sure if it's always 4096 characters, or if that's configured somewhere.

It's not completely obvious exactly what this function is supposed to accept, but I've tried to catch the case I saw while allowing non-strings and short strings.