### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
   - nightly
 
@@ -14,6 +15,10 @@ before_script:
   - composer install --no-interaction
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: nightly
+    - php: hhvm
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "yosymfony/toml": "0.3.*@dev",
-        "symfony/yaml": "^2.7|^3.0"
+        "symfony/yaml": "^2.7|^3.0",
+        "phpunit/phpunit": "^4.8|^6.5|^7.0"
     },
     "suggest": {
         "yosymfony/toml": "0.3.*",
@@ -24,6 +25,9 @@
     },
     "autoload": {
         "psr-4": { "Yosymfony\\ConfigLoader\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Yosymfony\\ConfigLoader\\Tests\\": "tests/" }
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,11 +12,7 @@
 
     <filter>
         <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./vendor</directory>
-                <directory>./Tests</directory>
-            </exclude>
+            <directory>./src</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -16,8 +16,9 @@ use Yosymfony\ConfigLoader\Config;
 use Yosymfony\ConfigLoader\Loaders\TomlLoader;
 use Yosymfony\ConfigLoader\Loaders\YamlLoader;
 use Yosymfony\ConfigLoader\Loaders\JsonLoader;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     protected $config;
 
@@ -30,6 +31,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             new YamlLoader($locator),
             new JsonLoader($locator),
         ));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The Array of loaders is empty
+     */
+    public function testConstructorOnEmptyLoader()
+    {
+        $config = new Config(array());
     }
 
     public function provideFileFormats()

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -19,8 +19,9 @@ use Yosymfony\ConfigLoader\Repository;
 use Yosymfony\ConfigLoader\Loaders\TomlLoader;
 use Yosymfony\ConfigLoader\Loaders\YamlLoader;
 use Yosymfony\ConfigLoader\Loaders\JsonLoader;
+use PHPUnit\Framework\TestCase;
 
-class RepositoryTest extends \PHPUnit_Framework_TestCase
+class RepositoryTest extends TestCase
 {
     protected $config;
 
@@ -33,6 +34,46 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
             new YamlLoader($locator),
             new JsonLoader($locator),
         ));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage This repository only accept configuration from arrays
+     */
+    public function testLoadShouldThrowInvalidArgumentException()
+    {
+        $repository = new Repository();
+        $repository->load(null);
+    }
+
+    public function testRewindShouldReturnFalse()
+    {
+        $repository = new Repository();
+        $this->assertFalse($repository->rewind());
+    }
+
+    public function testCurrentShouldReturnFalse()
+    {
+        $repository = new Repository();
+        $this->assertFalse($repository->current());
+    }
+
+    public function testKeyShouldReturnNull()
+    {
+        $repository = new Repository();
+        $this->assertNull($repository->key());
+    }
+
+    public function testNextShouldReturnNull()
+    {
+        $repository = new Repository();
+        $this->assertFalse($repository->next());
+    }
+
+    public function testValidShouldReturnFalse()
+    {
+        $repository = new Repository();
+        $this->assertFalse($repository->valid());
     }
 
     public function testRepositoryAddKey()
@@ -181,6 +222,10 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
     {
         $repository = $this->config->load("port = 25\n server = \"localhost\"", Config::TYPE_TOML);
         $repository->validateWith(new ConfigDefinitions());
+        $repoArray = $repository->getArray();
+
+        $this->assertSame(25, $repoArray['port']);
+        $this->assertSame('localhost', $repoArray['server']);
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Add ```php-7.2``` test in Travis CI build.
- Set the different PHPUnit versions for different PHP versions.
- Set the correct PHPUnit white filter lists.
- Add more tests.
- Use the class-based PHPUnit namespace to be compatible with the stable PHPUnit version.